### PR TITLE
Updating ORCA Documentation Domain

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -1,5 +1,5 @@
 # Sample workflow for building and deploying a Hugo site to GitHub Pages
-name: Deploy Hugo site to Pages
+name: Deploy Hugo site to hi-snr-labsite # Pages
 
 on:
   # Runs on pushes targeting the default branch
@@ -12,9 +12,9 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write # read
+  # pages: write
+  # id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -84,14 +84,29 @@ jobs:
         with:
           path: ./public
 
-  # Deployment job
+  # Deployment job (Deploy to HiSnrLab)
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+
     steps:
-      - name: Deploy to GitHub Pages
+      - name: Deploy to HiSnrLab
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.MYSITE_TOKEN }}
+          external_repository: HI-SNR-Lab/HI-SNR.github.io
+          publish_dir: ./public
+          destination_dir: orca
+
+  # # Deployment job (Deploy to HiSnrLab)
+  # deploy:
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   steps:
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       uses: actions/deploy-pages@v4

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -52,5 +52,7 @@ Use our guide to build MAPPERR, a multi-frequency snowmobile-towed ice-penetrati
 {{% /blocks/section %}}
 
 {{% blocks/lead %}}
-ORCA was developed by the Stanford Radio Glaciology Lab. Check out our other cool work [here](https://www.radioglaciology.com)! 
+ORCA is currently being developed by the University of Colorado Boulder in the Hi-SNR Laboratory. Find their website [here](https://hi-snr-lab.github.io/HI-SNR.github.io/)
+
+ORCA was originally developed by the Stanford Radio Glaciology Lab, whose cool work can be found [here](https://www.radioglaciology.com)! 
 {{% /blocks/lead %}}

--- a/content/en/about/index.md
+++ b/content/en/about/index.md
@@ -25,31 +25,46 @@ citation for all uses of ORCA is:
 
 # Contributors
 
-{{< cardpane >}}
-{{< card header="**Dustin Schreoder**" title="Principal Investigator">}}
+## HiSNR Laboratory
 
+{{< cardpane >}}
+
+{{< card header="**Nicole Bienert**" title="Principal Investigator">}}
+{{< fa "fa-solid fa-laptop" "https://hi-snr-lab.github.io/HI-SNR.github.io/" >}}
+{{< fa "fa-solid fa-envelope" "mailto:bienert@colorado.edu" >}}
+{{< /card >}}
+
+{{< card header="**Zoe Worrall**" title="Lead Developer for ORCA">}}
+{{< fa "fab fa-github" "https://github.com/zoe-worrall" >}}
+{{< fa "fa-solid fa-envelope" "mailto:zoe.worrall@colorado.edu" >}}
+{{< /card >}}
+
+{{< /cardpane >}}
+
+##  Radio Glaciology Laboratory
+
+{{< cardpane >}}
+
+{{< card header="**Dustin Schreoder**" title="Principal Investigator">}}
 {{< fa "fa-solid fa-laptop" "https://www.radioglaciology.com/" >}}
 {{< fa "fa-solid fa-envelope" "mailto:Dustin.M.Schroeder@stanford.edu" >}}
-
 {{< /card >}}
-{{< card header="**Anna Broome**" title="Lead Developer for ORCA and MAPPER">}}
 
+{{< card header="**Anna Broome**" title="Lead Developer for ORCA and MAPPER">}}
 {{< fa "fab fa-github" "https://github.com/albroome" >}}
 {{< fa "fa-solid fa-envelope" "mailto:abroome@stanford.edu" >}}
-
 {{< /card >}}
-{{< card header="**Thomas Teisberg**" title="Lead Developer for ORCA and Peregrine" >}}
 
+{{< card header="**Thomas Teisberg**" title="Lead Developer for ORCA and Peregrine" >}}
 {{< fa "fa-solid fa-laptop" "https://www.thomasteisberg.com/" >}}
 {{< fa "fab fa-github" "https://github.com/thomasteisberg" >}}
 {{< fa "fa-solid fa-envelope" "mailto:teisberg@stanford.edu" >}}
-
 {{< /card >}}
+
 {{< card header="**Dennis Woo**" title="Undergraduate Researcher">}}
-
 {{< fa "fab fa-github" "https://github.com/d-enniswoo" >}}
-
 {{< /card >}}
+
 {{< /cardpane >}}
 
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://orca.radioglaciology.com/"
+baseURL = "https://hi-snr-lab.github.io/HI-SNR.github.io/orca/"
 title = "Open Radar Code Architecture"
 
 # Language settings


### PR DESCRIPTION
Alters hugo.yaml and hugo.toml so that the website is fowarded to the HI-SNR-lab website's domain.

Adds Nicole Bienert as a potential contact for ORCA.