### PR TITLE
Changes actions to peaceiris/actions in hugo.yaml

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -80,7 +80,7 @@ jobs:
             ${{ runner.temp }}/hugo_cache
           key: ${{ steps.cache-restore.outputs.cache-primary-key }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: peaceiris/actions-gh-pages@v3
         with:
           path: ./public
 
@@ -100,3 +100,7 @@ jobs:
           publish_dir: ./public
           destination_dir: orca
           enable_jekyll: false
+
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Because of actions preparing artifacts but not deploying to alternate site, some issues with only reading ReadMe occur.

Changes actions/upload-pages-artifact@v3 to peaceiris/actions-gh-pages@v3 in hugo.yaml