### PR TITLE
Alters baseURL in hugo.toml

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -75,10 +75,6 @@ jobs:
           path: |
             ${{ runner.temp }}/hugo_cache
           key: ${{ steps.cache-restore.outputs.cache-primary-key }}
-      - name: Upload artifact
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          path: ./public
 
   # Deployment job (Deploy to HiSnrLab)
   deploy:
@@ -95,6 +91,7 @@ jobs:
           publish_branch: gh-pages
           publish_dir: ./public
           destination_dir: orca
+          keep_files: true
           enable_jekyll: false
 
   #   environment:

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,4 @@
-baseURL = "https://hi-snr-lab.github.io/HI-SNR.github.io/orca/"
-relativeURLs = true
-canonifyURLs = true
+baseURL = "https://hi-snr-lab.github.io/orca/"
 title = "Open Radar Code Architecture"
 
 # Language settings


### PR DESCRIPTION
Changes baseURL in hugo.toml, as it shouldn't be in the same website repository as HI-SNR.github.io

Stops uploading artifacts, as it's deploying artifacts twice which may break things, as there is already a peaceiris/actions-gh-pages@v3 command in the file.