### PR TITLE
Changes baseURL in hugo.toml

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://hi-snr-lab.github.io/orca/"
+baseURL = "https://hi-snr-lab.github.io/HI-SNR.github.io/orca/"
 title = "Open Radar Code Architecture"
 
 # Language settings


### PR DESCRIPTION
Changes hugo.toml so that it points to the correct website address in HI-SNR-Lab.