### PR TITLE
Adds relativeURLs and changes baseURL again

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,6 @@
-baseURL = "https://hi-snr-lab.github.io/HI-SNR.github.io/orca/"
+baseURL = "https://hi-snr-lab.github.io/orca/"
+relativeURLs = true
+canonifyURLs = true
 title = "Open Radar Code Architecture"
 
 # Language settings


### PR DESCRIPTION
Adds relativeURLs to be true, and changes the base URL to not be through the HI-SNR.github.io repository.

A lot of commits and pushes, but I am troubleshooting getting the linkage from orca-documentation to Hi-SNR-Lab correct