### PR TITLE
Add gpsd and clients to user-data

### DIFF
--- a/static/cloud-init/user-data
+++ b/static/cloud-init/user-data
@@ -39,6 +39,8 @@ packages:
 - i2c-tools
 - rpi.gpio-common
 - util-linux-extra
+- gpsd
+- gpsd-clients
 
 ## Write arbitrary files to the file-system
 write_files:


### PR DESCRIPTION
This is a duplicate of a PR on the old [radioglaciology/orca-documentation](https://github.com/radioglaciology/orca-documentation) repo (https://github.com/radioglaciology/orca-documentation/pull/1). It adds the `gpsd` and `gpsd-clients` apt packages to list of dependencies installed on the Pi during initial setup. This is important because gpsd and its clients (especially `gpxlogger` and `gpspipe`) are required for the logging scripts merged in https://github.com/HI-SNR-Lab/uhd_radar/pull/30. This will be useful for anyone putting together new radar units in the future!

Here's the original PR message on the old commit:

> Adding GPSD allows for easy access to a UBlox GPS received connected via USB. The GPSD clients provide the ability to log GPX, RINEX, and JSON data from the GPS, which is useful for postprocessing and required for georeferencing the radar samples. I used this setup in Antarctica in 2025 and would love for it to be merged into the main project!